### PR TITLE
Improve supply‑demand script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Supply and Demand Equilibrium Script
+
+This script fits linear or quadratic models to supply and demand observations,
+computes the market equilibrium and price elasticity and plots the resulting
+curves. Data can be entered manually or loaded from CSV files using command
+line options.
+
+## Usage
+
+```
+python Econometry.8.py [--mode manual|csv] [--demand-file FILE] [--supply-file FILE] [--no-plot]
+```
+
+If `--mode csv` is used, both `--demand-file` and `--supply-file` must be
+provided. When not using `--no-plot` the supply and demand curves will be shown
+interactively.


### PR DESCRIPTION
## Summary
- add module documentation and argparse CLI
- provide docstrings for all helper functions
- restructure script into a `main()` entry point
- save README with basic usage instructions

## Testing
- `python -m py_compile Econometry.8.py`


------
https://chatgpt.com/codex/tasks/task_e_687e5269c5608322a8d6ba21676095cf